### PR TITLE
Feat(#16) - Implement struct literal

### DIFF
--- a/crates/ast/src/delimited.rs
+++ b/crates/ast/src/delimited.rs
@@ -58,17 +58,12 @@ impl Indexing {
         get_children_in(node, SyntaxKind::Indexing)
     }
     pub fn index(&self) -> ASTResult<Expr> {
-        if let Some(node) = self
-            .0
-            .children()
-            .filter(|node_or_token| {
-                !matches!(
-                    node_or_token.kind(),
-                    SyntaxKind::LBrack | SyntaxKind::RBrack
-                )
-            })
-            .next()
-        {
+        if let Some(node) = self.0.children().find(|node_or_token| {
+            !matches!(
+                node_or_token.kind(),
+                SyntaxKind::LBrack | SyntaxKind::RBrack
+            )
+        }) {
             Expr::try_from(&node)
         } else {
             Err(error_for_node(&self.0, "non empty child"))

--- a/crates/hir/src/container_ref.rs
+++ b/crates/hir/src/container_ref.rs
@@ -34,7 +34,7 @@ impl HIRBuilder {
             let low_indexing = self.lower_indexing(idx)?;
             lowered_indices.push(low_indexing);
         }
-        let span: Span = container_ref.span();
+        let span: Span = container_ref.span().into();
 
         Ok(Unresolved::baggaged(
             name,

--- a/crates/hir/src/context.rs
+++ b/crates/hir/src/context.rs
@@ -1,6 +1,6 @@
 use crate::scope::ScopeIdx;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
 pub enum UsageContext {
     Ref, // borrowing
     RefMut,
@@ -11,6 +11,7 @@ pub enum UsageContext {
     Mut,       // declared as mut
     Read,      // non-mut read
     ReadWrite, // x *= 2;
+    #[default]
     Return,
     StructInit,
     Unknown,

--- a/crates/hir/src/delimited.rs
+++ b/crates/hir/src/delimited.rs
@@ -34,7 +34,7 @@ impl Default for Block {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct Indexing(pub(crate) ExprIdx);
 
 impl HIRBuilder {

--- a/crates/hir/src/function.rs
+++ b/crates/hir/src/function.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
-pub struct RetType(Type);
+pub struct RetType(pub Type);
 
 // TODO: what to put in the arena now?
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
@@ -34,7 +34,7 @@ pub struct Callable {
     pub return_type: Option<RetType>,
     pub body: Block,
 }
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 // TODO: add metadata
 pub struct FnDef {
     pub name_index: StrIdx,
@@ -61,7 +61,7 @@ impl Default for FnDef {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct FnArg(pub ExprIdx);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -72,8 +72,8 @@ pub enum On {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Call {
-    on: On,
-    arguments: ThinVec<FnArg>,
+    pub on: On,
+    pub arguments: ThinVec<FnArg>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/hir/src/function.rs
+++ b/crates/hir/src/function.rs
@@ -102,7 +102,7 @@ impl HIRBuilder {
                 ResolutionType::Fn,
             )),
             ASTOn::Literal(literal) => {
-                let literal = self.lower_literal(&literal)?;
+                let literal = self.lower_literal(literal)?;
                 let on = On::Literal(literal);
                 MayNeedResolution::No(Call { on, arguments })
             }

--- a/crates/hir/src/literal.rs
+++ b/crates/hir/src/literal.rs
@@ -60,6 +60,10 @@ impl HIRBuilder {
                 let idx = self.allocate_string(string);
                 Value::Str(idx)
             }
+            ASTValue::Struct(ast_struct_literal) => {
+                let lowered_struct_literal = self.lower_struct_literal(&ast_struct_literal)?;
+                Value::Struct(lowered_struct_literal)
+            }
             ASTValue::Lambda(lambda) => {
                 let c = self.lower_callable(&lambda.0)?;
                 Value::Lambda(c)
@@ -83,5 +87,58 @@ impl HIRBuilder {
             primitive => Value::from(&primitive),
         };
         Ok(Literal(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ast::{cast_node_into_type, literal::Literal as ASTLiteral};
+
+    use super::*;
+    use crate::{
+        builder::tests::ast_root_from,
+        literal::Value,
+        resolution::Reference,
+        scope::{ExprIdx, MetaHolder, into_idx},
+        structure::{InternalStructure, StructRef},
+    };
+
+    #[test]
+    fn struct_literal() {
+        let program = "Point{x:0, y:0, z:0, t:0}";
+
+        let ast_root = ast_root_from(program);
+        let ast_struct_literal =
+            cast_node_into_type::<ASTLiteral>(ast_root.get_root().first_child().as_ref().unwrap());
+
+        let mut hir_builder = HIRBuilder::new(ast_root);
+        let lowered_struct_literal = hir_builder
+            .lower_literal(&ast_struct_literal)
+            .expect("should have been ok");
+
+        let scope_idx = hir_builder.current_scope_cursor;
+
+        let struct_literal = if let Literal(Value::Struct(struct_literal)) = lowered_struct_literal
+        {
+            struct_literal
+        } else {
+            panic!("should have been a struct literal");
+        };
+
+        assert_eq!(
+            Reference::<StructRef>::Unresolved(into_idx(0)),
+            struct_literal.struct_ref
+        );
+
+        assert_eq!(MetaHolder::default(), struct_literal.field_metadata);
+
+        let mut internal = InternalStructure::<ExprIdx>::new(scope_idx);
+        for (ix, field_name) in ["x", "y", "z", "t"].iter().enumerate() {
+            internal
+                .add((*field_name).into(), into_idx(ix as u32 + 1))
+                .expect("should have been successful to populate internal structure");
+        }
+
+        assert_eq!(internal, struct_literal.internal_with_field_values);
     }
 }

--- a/crates/hir/src/literal.rs
+++ b/crates/hir/src/literal.rs
@@ -9,6 +9,7 @@ use crate::{
     container::{Shape, canonical::CanonicalBuffer, layout::Layout},
     function::Callable,
     scope::{ContainerLiteralIdx, StrIdx},
+    structure::StructLiteral,
     typing::hindley_milner::types::{Maybe, Type},
 };
 
@@ -25,7 +26,7 @@ pub enum Value {
     Lambda(Callable),
     Int(i32),
     Str(StrIdx),
-    // Struct
+    Struct(StructLiteral),
     Tensor {
         idx: ContainerLiteralIdx,
         shape: ThinVec<Option<usize>>,

--- a/crates/hir/src/metadata.rs
+++ b/crates/hir/src/metadata.rs
@@ -1,21 +1,15 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-};
+use std::fmt::Debug;
 
 use thin_vec::ThinVec;
 
 use crate::{
-    HIRResult,
     context::{LoweringContext, UsageContext},
-    errors::HIRError,
-    literal::Value,
     scope::{ScopeIdx, Span},
     typing::hindley_milner::types::Type,
 };
 
 pub type Usages = ThinVec<Usage>;
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct Usage {
     pub kind: UsageContext,
     pub span: Span,
@@ -41,7 +35,7 @@ pub struct BlkMeta {
     pub capturing_indices: ThinVec<usize>, // Indices of statements within the block that capture variables from the parent scope
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct VarMeta {
     pub def: Usage,
     pub of_type: Type,

--- a/crates/hir/src/resolution.rs
+++ b/crates/hir/src/resolution.rs
@@ -134,7 +134,7 @@ where
     Err(ResolutionError::new_with_guestimate(key, guesstimates).into())
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub enum Baggage {
     None,
     Arg(ThinVec<FnArg>),
@@ -165,7 +165,7 @@ impl Unresolved {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub enum Reference<R> {
     Unresolved(Idx<Unresolved>),
     Resolved {

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -26,7 +26,31 @@ pub type VarDefIdx = Idx<VarDef>;
 
 pub type NameToIndexTrie<T> = PatriciaMap<Idx<T>>;
 
-pub type Span = Range<usize>;
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let result = self.start.partial_cmp(&other.end);
+        if let Some(std::cmp::Ordering::Greater) = result {
+            result
+        } else {
+            self.end.partial_cmp(&other.start)
+        }
+    }
+}
+
+impl From<Range<usize>> for Span {
+    fn from(value: Range<usize>) -> Self {
+        Self {
+            start: value.start,
+            end: value.end,
+        }
+    }
+}
 
 pub(crate) fn into_idx<T>(from: u32) -> Idx<T> {
     Idx::from_raw(RawIdx::from_u32(from))

--- a/crates/hir/src/scope.rs
+++ b/crates/hir/src/scope.rs
@@ -14,7 +14,7 @@ use crate::{
     variable::VarDef,
 };
 
-use std::{collections::HashMap, fmt::Debug, ops::Range};
+use std::{cmp::Ordering, collections::HashMap, fmt::Debug, ops::Range};
 
 pub type ExprIdx = Idx<Expr>;
 pub type FnDefIdx = Idx<FnDef>;
@@ -33,10 +33,12 @@ pub struct Span {
 }
 
 impl PartialOrd for Span {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let result = self.start.partial_cmp(&other.end);
-        if let Some(std::cmp::Ordering::Greater) = result {
-            result
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if let Some(result) = self.start.partial_cmp(&other.end) {
+            match result {
+                Ordering::Greater | Ordering::Less => Some(result),
+                Ordering::Equal => self.end.partial_cmp(&other.start),
+            }
         } else {
             self.end.partial_cmp(&other.start)
         }

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -74,7 +74,7 @@ impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> PartialOrd for Interna
 }
 
 impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> InternalStructure<TorV> {
-    fn new(scope_idx: ScopeIdx) -> Self {
+    pub fn new(scope_idx: ScopeIdx) -> Self {
         Self {
             scope_idx,
             ..Default::default()

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -1,3 +1,4 @@
+use core::hash::Hash;
 use std::fmt::Debug;
 
 use la_arena::Arena;
@@ -25,13 +26,13 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct InternalStructure<TorV: Clone + Debug + PartialEq> {
+pub struct InternalStructure<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> {
     pub field_name_to_index: PatriciaMap<u32>,
     pub field_names: Arena<SmolStr>,
     pub data: Arena<TorV>,
     pub scope_idx: ScopeIdx,
 }
-impl<TorV: Clone + Debug + PartialEq> PartialEq for InternalStructure<TorV> {
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> PartialEq for InternalStructure<TorV> {
     fn eq(&self, other: &Self) -> bool {
         self.scope_idx == other.scope_idx
             && self.data == other.data
@@ -42,7 +43,9 @@ impl<TorV: Clone + Debug + PartialEq> PartialEq for InternalStructure<TorV> {
                 .eq(other.field_name_to_index.iter())
     }
 }
-impl<TorV: Clone + Debug + PartialEq> Default for InternalStructure<TorV> {
+
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> Eq for InternalStructure<TorV> {}
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> Default for InternalStructure<TorV> {
     fn default() -> Self {
         Self {
             field_name_to_index: Default::default(),
@@ -53,14 +56,31 @@ impl<TorV: Clone + Debug + PartialEq> Default for InternalStructure<TorV> {
     }
 }
 
-impl<TorV: Clone + Debug + PartialEq> InternalStructure<TorV> {
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> Hash for InternalStructure<TorV> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.field_name_to_index
+            .iter()
+            .for_each(|tuple| tuple.hash(state));
+        self.field_names.hash(state);
+        self.data.iter().for_each(|d| d.hash(state));
+        self.scope_idx.hash(state);
+    }
+}
+
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> PartialOrd for InternalStructure<TorV> {
+    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+        None
+    }
+}
+
+impl<TorV: Clone + Debug + Hash + PartialEq + PartialOrd> InternalStructure<TorV> {
     fn new(scope_idx: ScopeIdx) -> Self {
         Self {
             scope_idx,
             ..Default::default()
         }
     }
-    fn add(&mut self, name: SmolStr, data: TorV) -> HIRResult<()> {
+    pub fn add(&mut self, name: SmolStr, data: TorV) -> HIRResult<()> {
         if self.field_names.len() != self.data.len() {
             return Err(HIRError::with_msg(format!(
                 "Struct field allocation encountered mismatched indices: 'name index: {:?}' != 'data index: {:?}'",
@@ -76,7 +96,7 @@ impl<TorV: Clone + Debug + PartialEq> InternalStructure<TorV> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct StructDef {
     pub internal_with_field_types: InternalStructure<Type>,
     pub name_index: StrIdx,
@@ -100,7 +120,7 @@ impl NameIndexed for StructDef {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct StructRef(pub StructDefIdx);
 
 impl Default for StructRef {
@@ -108,11 +128,27 @@ impl Default for StructRef {
         Self(placeholder_idx())
     }
 }
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StructLiteral {
     pub struct_ref: Reference<StructRef>,
     pub internal_with_field_values: InternalStructure<ExprIdx>,
     pub field_metadata: MetaHolder<VarDef, VarMeta>,
+}
+
+impl PartialOrd for StructLiteral {
+    fn partial_cmp(&self, _: &Self) -> Option<std::cmp::Ordering> {
+        None
+    }
+}
+
+impl Hash for StructLiteral {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.struct_ref.hash(state);
+        self.internal_with_field_values.hash(state);
+        self.field_metadata
+            .iter()
+            .for_each(|tuple| tuple.hash(state));
+    }
 }
 
 impl HIRBuilder {
@@ -164,7 +200,7 @@ impl HIRBuilder {
         }
 
         let struct_literal = StructLiteral {
-            field_metadata: MetaHolder::new(),
+            field_metadata: MetaHolder::default(),
             internal_with_field_values: internal,
             struct_ref,
         };

--- a/crates/hir/src/typing/hindley_milner/expression.rs
+++ b/crates/hir/src/typing/hindley_milner/expression.rs
@@ -220,6 +220,7 @@ impl TryFrom<&Value> for HMExpr {
                 shape: shape.clone(),
             }),
             Value::Lambda(callable) => todo!(),
+            Value::Struct(struct_literal) => todo!(),
         }
     }
 }

--- a/crates/hir/src/typing/hindley_milner/types.rs
+++ b/crates/hir/src/typing/hindley_milner/types.rs
@@ -6,7 +6,10 @@ use std::collections::HashSet;
 use la_arena::Idx;
 use thin_vec::{ThinVec, thin_vec};
 
-use crate::{literal::Value, resolution::Unresolved};
+use crate::{
+    literal::Value,
+    resolution::{Reference, Unresolved},
+};
 
 use super::{inference::TypeKey, store::TypeVarId};
 
@@ -87,6 +90,13 @@ impl From<&Value> for Type {
                 data_type: data_type.clone(),
             },
             Value::Lambda(callable) => todo!(),
+            Value::Struct(struct_literal) => todo!(), // {
+                                                      // Reference::Unresolved(idx) => todo!(),
+                                                      // Reference::Resolved { name_idx, .. } => Type::Struct {
+                                                      //     key: name_idx,
+                                                      //     fields: struct_literal.internal_with_field_values.data.iter().map(|(_idx, expr_idx)| ).collect::<ThinVec<_>>(),
+                                                      // },
+                                                      // },
         }
     }
 }

--- a/crates/hir/src/variable.rs
+++ b/crates/hir/src/variable.rs
@@ -17,7 +17,7 @@ use crate::{
     resolution::{Reference, ResolutionType, Unresolved, resolve},
     scope::{ExprIdx, NameIndexed, Span, StrIdx, VarDefIdx, VarSelector, placeholder_idx},
 };
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd)]
 pub struct VarDef {
     pub name_index: StrIdx,
     pub expr_index: ExprIdx,
@@ -47,33 +47,33 @@ impl HIRBuilder {
     }
     fn store_metadata_for_var_def(
         &mut self,
-        ast_var_def: &ASTVarDef,
-        idx: Idx<VarDef>,
-        expr_idx: ExprIdx,
+        _ast_var_def: &ASTVarDef,
+        _idx: Idx<VarDef>,
+        _expr_idx: ExprIdx,
     ) -> HIRResult<()> {
-        let span = ast_var_def.span();
-        self.allocate_span(ast_var_def.name(), span.clone());
-        let usage_for_def = {
-            let l_ctx = self.get_context().expect("a context");
-            Usage::from(l_ctx, span, self.get_current_stmt_idx())
-        };
-        let of_type = if let Some(ASTHint::Type(type_hint)) = ast_var_def.type_hint() {
-            self.lower_type(type_hint)?;
-        } else {
-            todo!()
-        };
-        let scope = self.get_current_scope_mut();
-        scope.metadata.vars.insert(
-            idx,
-            VarMeta {
-                def: usage_for_def,
-                usages: Usages::new(),
-                is_mut: ast_var_def.is_mut(),
-                first_read_idx: None,
-                first_write_idx: None,
-                of_type: todo!(), // should be able to infer this?
-            },
-        );
+        // let span = ast_var_def.span();
+        // self.allocate_span(ast_var_def.name(), span.clone().into());
+        // let usage_for_def = {
+        //     let l_ctx = self.get_context().expect("a context");
+        //     Usage::from(l_ctx, span.into(), self.get_current_stmt_idx())
+        // };
+        // let of_type = if let Some(ASTHint::Type(type_hint)) = ast_var_def.type_hint() {
+        //     self.lower_type(type_hint)?;
+        // } else {
+        // };
+        // let scope = self.get_current_scope_mut();
+        // scope.metadata.vars.insert(
+        //     idx,
+        //     VarMeta {
+        //         def: usage_for_def,
+        //         usages: Usages::new(),
+        //         is_mut: ast_var_def.is_mut(),
+        //         first_read_idx: None,
+        //         first_write_idx: None,
+        //         of_type: todo!(), // should be able to infer this?
+        //     },
+        // );
+        todo!()
     }
     #[with_context(UsageContext::Init)]
     pub fn lower_var_def(&mut self, ast_var_def: &ASTVarDef) -> HIRResult<VarDefIdx> {
@@ -91,7 +91,7 @@ impl HIRBuilder {
     }
     pub fn lower_var_ref(&mut self, var_ref: &ASTVarRef) -> HIRResult<Unresolved> {
         let name = var_ref.name().clone();
-        let span: Span = var_ref.span();
+        let span: Span = var_ref.span().into();
         let low_var_ref = Unresolved::new(name, ResolutionType::Var(span));
         Ok(low_var_ref)
     }
@@ -102,18 +102,18 @@ impl HIRBuilder {
         let scope_climbing_iter = climb(self.current_scope_cursor, &self.scopes);
         let resolved_reference = resolve::<VarDef, VarSelector>(scope_climbing_iter, unresolved)?;
 
-        let scope = self.get_current_scope_mut();
-        let usage = todo!();
-        if let Some(meta) = scope
-            .metadata
-            .vars
-            .get_mut(&resolved_reference.get_obj_index()?)
-        {
-            meta.usages.push(usage);
-            if meta.first_read_idx.is_none() {
-                meta.first_read_idx = Some(self.get_current_stmt_idx());
-            }
-        }
+        // let scope = self.get_current_scope_mut();
+        // let usage = todo!();
+        // if let Some(meta) = scope
+        //     .metadata
+        //     .vars
+        //     .get_mut(&resolved_reference.get_obj_index()?)
+        // {
+        //     meta.usages.push(usage);
+        //     if meta.first_read_idx.is_none() {
+        //         meta.first_read_idx = Some(self.get_current_stmt_idx());
+        //     }
+        // }
 
         Ok(resolved_reference)
     }

--- a/crates/syntax/src/bitset.rs
+++ b/crates/syntax/src/bitset.rs
@@ -47,6 +47,7 @@ impl Default for SyntaxKindBitSet {
     }
 }
 #[allow(clippy::suspicious_arithmetic_impl)]
+#[allow(clippy::suspicious_op_assign_impl)]
 impl Add for SyntaxKindBitSet {
     type Output = SyntaxKindBitSet;
 
@@ -56,6 +57,7 @@ impl Add for SyntaxKindBitSet {
 }
 
 #[allow(clippy::suspicious_arithmetic_impl)]
+#[allow(clippy::suspicious_op_assign_impl)]
 impl AddAssign for SyntaxKindBitSet {
     fn add_assign(&mut self, rhs: Self) {
         self.0 |= rhs.0;
@@ -63,6 +65,7 @@ impl AddAssign for SyntaxKindBitSet {
 }
 
 #[allow(clippy::suspicious_arithmetic_impl)]
+#[allow(clippy::suspicious_op_assign_impl)]
 impl AddAssign for &mut SyntaxKindBitSet {
     fn add_assign(&mut self, rhs: Self) {
         self.0 |= rhs.0;


### PR DESCRIPTION
## Pull Request Overview

This PR implements support for struct literal expressions in the compiler’s HIR along with various trait and API improvements. Key changes include:
- Adding struct literal handling in the HIR and type systems.
- Updating derives and trait bounds (e.g., Hash, PartialOrd) on several core types.
- Refactoring span conversion and API usage across modules.

### Reviewed Changes

Copilot reviewed 14 out of 14 changed files in this pull request and generated 2 comments.

<details>
<summary>Show a summary per file</summary>

| File                                       | Description                                                       |
| ------------------------------------------ | ----------------------------------------------------------------- |
| crates/syntax/src/bitset.rs                 | Added additional clippy lint allowances for operator assignments. |
| crates/hir/src/variable.rs                  | Updated VarDef derives and commented out metadata handling code.   |
| crates/hir/src/typing/hindley_milner/types.rs | Added a new match arm for Value::Struct with a placeholder.         |
| crates/hir/src/typing/hindley_milner/expression.rs | Added a placeholder for struct literal conversion.                  |
| crates/hir/src/structure.rs                  | Expanded trait bounds and implementations for struct types.         |
| crates/hir/src/scope.rs                      | Replaced the Span alias with a struct and implemented custom ordering logic. |
| crates/hir/src/resolution.rs                 | Enhanced derives for resolution-related enums.                      |
| crates/hir/src/metadata.rs                   | Adjusted derives to include more trait bounds.                      |
| crates/hir/src/literal.rs                    | Introduced AST literal conversion for struct literals and added tests.|
| crates/hir/src/function.rs                   | Made field adjustments in FnDef and FnArg for consistency.            |
| crates/hir/src/delimited.rs                  | Added PartialOrd derive to Indexing.                                  |
| crates/hir/src/context.rs                    | Updated UsageContext derives and ordering.                           |
| crates/hir/src/container_ref.rs              | Updated span conversion with explicit Into conversion.                |
| crates/ast/src/delimited.rs                  | Refactored Indexing::index() to use a more concise pattern.             |
</details>




